### PR TITLE
fix: Update gitpod link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once you run the application, you can send traces to Honeycomb. Then you can pra
 
 ### GitPod setup
 
-Go to [Gitpod](https://honeycombio-academyinst-i0cuptb35ss.ws-us110.gitpod.io/) to open the repository.
+Go to [Gitpod](https://gitpod.io/#https://github.com/honeycombio/academy-instrumentation-python) to launch this project in Gitpod.
 
 Confirm the workspace creation. You can work in the browser with VS Code Browser or in your local code editor.
 


### PR DESCRIPTION
## Short description of the changes
I guess we shouldn't link directly to people's Gitpod workspaces, so do what the Gitpod docs say instead

## How to verify that this has the expected result
