### PR TITLE
feat: Dev improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "Python 3",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.11",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            "settings": {
+                "files.trimTrailingWhitespace": true,
+                "files.trimFinalNewlines": true,
+                "terminal.integrated.defaultLocation": "editor",
+                "git.autofetch": true,
+            },
+            "extensions": [
+                "ms-python.python",
+                "GitHub.copilot",
+                "GitHub.copilot-chat"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [9000],
+    // Use 'portsAttributes' to set default properties for specific forwarded ports.
+    // More info: https://containers.dev/implementors/json_reference/#port-attributes
+    "portsAttributes": {
+        "8080": {
+            "label": "Meminator",
+            "onAutoForward": "notify"
+        }
+    },
+    // 'updateContentCommand' runs commands during the Github codespaces prebuild process for every content change
+    "updateContentCommand": "sudo apt-get update && sudo apt-get install -y imagemagick",
+    // "postCreateCommand" - this runs after the container has launched
+    // create the DBT_PROFILE secret using the contents of your .dbt/profiles.yml here: https://github.com/settings/codespaces/secrets/new
+    // "postCreateCommand": "docker compose up --build"
+}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Once you run the application, you can send traces to Honeycomb. Then you can pra
 
 Go to [Gitpod](https://gitpod.io/#https://github.com/honeycombio/academy-instrumentation-python) to launch this project in Gitpod.
 
-Confirm the workspace creation. You can work in the browser with VS Code Browser or in your local code editor. The default settings are acceptable. 
+Confirm the workspace creation. You can work in the browser with VS Code Browser or in your local code editor. The default settings are acceptable.
 
 Once you are in the code editor, run `docker compose up` in the code editor's terminal. To stop running the application, run `ctrl+c`. Then run `docker compose down` to remove the container.
 
@@ -66,6 +66,9 @@ BUCKET_NAME="random-pictures"
 
 OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443/"
 OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
+
+# You can set this to "services-implemented-version" to run the answer-guide version
+SERVICE_PATH="services"
 ```
 
 If you don't have an API key handy, here is the [documentation](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   backend-for-frontend:
     build:
-      context: services/backend-for-frontend-python
+      context: ${SERVICE_PATH:-services}/backend-for-frontend-python
       dockerfile: Dockerfile
     image: backend-for-frontend-python:latest
     ports:
@@ -13,7 +13,7 @@ services:
 
   meminator:
     build:
-      context: services/meminator-python
+      context: ${SERVICE_PATH:-services}/meminator-python
       dockerfile: Dockerfile
     image: meminator-python:latest
     ports:
@@ -25,7 +25,7 @@ services:
 
   phrase-picker:
     build:
-      context: services/phrase-picker-python
+      context: ${SERVICE_PATH:-services}/phrase-picker-python
       dockerfile: Dockerfile
     image: phrase-picker-python:latest
     ports:
@@ -37,7 +37,7 @@ services:
 
   image-picker:
     build:
-      context: services/image-picker-python
+      context: ${SERVICE_PATH:-services}/image-picker-python
       dockerfile: Dockerfile
     image: image-picker-python:latest
     ports:
@@ -50,7 +50,7 @@ services:
 
   web:
     build:
-      context: services/web
+      context: ${SERVICE_PATH:-services}/web
       dockerfile: Dockerfile
       args:
         HONEYCOMB_API_KEY: ${HONEYCOMB_API_KEY}

--- a/example.env
+++ b/example.env
@@ -6,3 +6,6 @@ BUCKET_NAME="random-pictures"
 
 OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io:443/"
 OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
+
+# You can set this to "services-implemented-version" to run the answer-guide version
+SERVICE_PATH="services"


### PR DESCRIPTION
## Short description of the changes
- adds a Devcontainer for Codespaces use
- makes docker compose able to run from either the `services` or `services-implemented-version` or any other clone you make

## How to verify that this has the expected result
